### PR TITLE
Relax bounds for reflex-basic-host-0.2

### DIFF
--- a/nix/reflex-basic-host.json
+++ b/nix/reflex-basic-host.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/qfpl/reflex-basic-host",
-  "rev": "22fa91611f1eb8ef2f1cc4aeb7c52484a4c75dc5",
-  "date": "2019-03-18T10:37:31+10:00",
-  "sha256": "03zgphm0dib5nizxbzakb02561r3wsdlj91zh2x6b853dpdgcc1y",
+  "rev": "d989d43fb920477f033dffe50f896eeacbccefac",
+  "date": "2019-06-27T22:07:39+10:00",
+  "sha256": "0dak3hbd3hhaa8lc0a43va41lkmjn3ffk98zp5blp3ajh3ijx2b6",
   "fetchSubmodules": false
 }

--- a/nix/reflex-platform.json
+++ b/nix/reflex-platform.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/reflex-frp/reflex-platform",
-  "rev": "465d4ce91255790046fe5d4e625bc1eacd324d00",
-  "date": "2019-03-17T20:42:43-04:00",
-  "sha256": "0d043rv7adv86kr3dmazn3brkpg4dh4xixjiimr7zxhas36bxizr",
+  "rev": "716879f16d53c93766e7ed9af17416fccb2edfe1",
+  "date": "2019-06-15T14:12:13-04:00",
+  "sha256": "1mngxa24cfpvxxq4hgh77nw36vny4abl5wi2xmlwpkk25wzm0h0x",
   "fetchSubmodules": false
 }

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -1,4 +1,5 @@
-#! /usr/bin/env bash
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p nix-prefetch-git
 
 nix-prefetch-git https://github.com/reflex-frp/reflex-platform > reflex-platform.json
 nix-prefetch-git https://github.com/qfpl/reflex-basic-host > reflex-basic-host.json

--- a/reflex-backend-servant.cabal
+++ b/reflex-backend-servant.cabal
@@ -4,8 +4,8 @@ license:             BSD3
 license-file:        LICENSE
 author:              Dave Laing
 maintainer:          dave.laing.80@gmail.com
--- copyright:           
--- category:            
+-- copyright:
+-- category:
 build-type:          Simple
 extra-source-files:  ChangeLog.md
 cabal-version:       >=1.10
@@ -24,15 +24,15 @@ library
                      , mtl               >= 2.2  && < 2.3
                      , network           >= 2.6  && < 3.1
                      , primitive         >= 0.6  && < 0.7
-                     , reflex            >= 0.5  && < 0.6
                      , ref-tf            >= 0.4  && < 0.5
+                     , reflex            >= 0.5  && < 0.7
+                     , reflex-basic-host >= 0.1  && < 0.3
                      , servant           >= 0.11 && < 0.17
                      , servant-server    >= 0.11 && < 0.17
                      , stm               >= 2.4  && < 2.6
                      , tagged            >= 0.8  && < 0.9
                      , ttrie             >= 0.1  && < 0.2
                      , wai               >= 3.2  && < 3.3
-                     , reflex-basic-host >= 0.1  && < 0.2
   hs-source-dirs:      src
   ghc-options:         -Wall
   default-language:    Haskell2010
@@ -45,18 +45,16 @@ executable example
                      , hashable          >= 1.2  && < 1.3
                      , http-api-data     >= 0.3  && < 0.5
                      , mtl               >= 2.2  && < 2.3
-                     , reflex            >= 0.5  && < 0.6
                      , ref-tf            >= 0.4  && < 0.5
+                     , reflex            >= 0.5  && < 0.7
+                     , reflex-backend-servant
+                     , reflex-basic-host >= 0.1  && < 0.3
                      , servant           >= 0.11 && < 0.17
                      , servant-server    >= 0.11 && < 0.17
                      , stm               >= 2.4  && < 2.6
                      , transformers      >= 0.5  && < 0.6
                      , wai               >= 3.2  && < 3.3
                      , warp              >= 3.2  && < 3.3
-                     , reflex-basic-host >= 0.1  && < 0.2
-                     , reflex-backend-servant
   hs-source-dirs:      exe
   ghc-options:         -Wall
   default-language:    Haskell2010
-
-

--- a/src/Reflex/Backend/Servant.hs
+++ b/src/Reflex/Backend/Servant.hs
@@ -65,7 +65,7 @@ serverGuest ::
   , HasServer api '[]
   , BasicGuestConstraints t m
   ) =>
-  Proxy api ->
+  Proxy (api :: *) ->
   IO tag ->
   (EventsIn' t tag () api -> BasicGuest t m (EventsOut t tag api)) ->
   BasicGuest t m (Application)


### PR DESCRIPTION
Do not merge until after qfpl/reflex-basic-host#7 is merged. Needs an update of reflex-basic-host.json also.